### PR TITLE
Specify default for profile.

### DIFF
--- a/polybot/bot.py
+++ b/polybot/bot.py
@@ -20,7 +20,7 @@ class Bot(object):
                                  help='Actually post updates. Without this flag, runs in dev mode.')
         self.parser.add_argument('--setup', action='store_true',
                                  help='Configure accounts')
-        self.parser.add_argument('--profile',
+        self.parser.add_argument('--profile', default='',
                                  help='Choose profile')
         self.name = name
         self.services = []  # type: List[Service]


### PR DESCRIPTION
Otherwise it errors with `object of type 'NoneType' has no len()`.

Note 0.4 on pypi does not match 0.4 here, as 0.4 has this error and on pypi does not (think it's actually the commit before profile was added).

