### PR TITLE
Fix missing things from previous merges

### DIFF
--- a/polybot/bot.py
+++ b/polybot/bot.py
@@ -115,6 +115,8 @@ class Bot(object):
         lon: float = None,
     ) -> dict:
         if isinstance(status, list):
+            if wrap:
+                raise ValueError('Cannot mix wrap and status list')
             if not len(status):
                 raise ValueError("Cannot supply an empty list")
         self.log.info("> %s", status)

--- a/polybot/bot.py
+++ b/polybot/bot.py
@@ -109,6 +109,7 @@ class Bot(object):
         status: Union[str, List[str]],
         wrap=False,
         imagefile=None,
+        mime_type=None,
         in_reply_to_id=None,
         lat: float = None,
         lon: float = None,
@@ -123,7 +124,7 @@ class Bot(object):
                 if in_reply_to_id:
                     in_reply_to_id = in_reply_to_id[service.name]
                 out[service.name] = service.post(
-                    status, wrap, imagefile, lat, lon, in_reply_to_id
+                    status, wrap, imagefile, mime_type, lat, lon, in_reply_to_id
                 )
             except PostError:
                 self.log.exception("Error posting to %s", service)

--- a/polybot/service.py
+++ b/polybot/service.py
@@ -171,7 +171,7 @@ class Twitter(Service):
                     imagefile = "dummy" + ext
                 else:
                     f = None
-                self.tweepy.update_with_media(
+                return self.tweepy.update_with_media(
                     imagefile,
                     status=status,
                     lat=lat,

--- a/polybot/service.py
+++ b/polybot/service.py
@@ -53,24 +53,30 @@ class Service(object):
             if isinstance(status, list):
                 status = self.longest_allowed(status, imagefile)
             if wrap:
-                return self.do_wrapped(status, imagefile, lat, lon, in_reply_to_id)
+                return self.do_wrapped(status, imagefile, mime_type, lat, lon, in_reply_to_id)
             else:
-                return self.do_post(status, imagefile, lat, lon, in_reply_to_id)
+                return self.do_post(status, imagefile, mime_type, lat, lon, in_reply_to_id)
             self.do_post(status, imagefile, lat, lon)
 
     def do_post(
         self,
         status: str,
         imagefile=None,
+        mime_type=None,
         lat: float = None,
         lon: float = None,
-        mime_type=None,
         in_reply_to_id=None,
     ) -> None:
         raise NotImplementedError()
 
     def do_wrapped(
-        self, status, imagefile=None, lat=None, lon=None, in_reply_to_id=None
+        self,
+        status,
+        imagefile=None,
+        mime_type=None,
+        lat=None,
+        lon=None,
+        in_reply_to_id=None
     ):
         max_len = self.max_length_image if imagefile else self.max_length
         if len(status) > max_len:
@@ -85,7 +91,7 @@ class Service(object):
                 line = u"\u2026%s" % line
 
             if imagefile and first:
-                out = self.do_post(line, imagefile, lat, lon, in_reply_to_id)
+                out = self.do_post(line, imagefile, mime_type, lat, lon, in_reply_to_id)
             else:
                 out = self.do_post(
                     line, lat=lat, lon=lon, in_reply_to_id=in_reply_to_id
@@ -154,9 +160,9 @@ class Twitter(Service):
         self,
         status,
         imagefile=None,
+        mime_type=None,
         lat=None,
         lon=None,
-        mime_type=None,
         in_reply_to_id=None,
     ):
         try:
@@ -238,9 +244,9 @@ class Mastodon(Service):
         self,
         status,
         imagefile=None,
+        mime_type=None,
         lat=None,
         lon=None,
-        mime_type=None,
         in_reply_to_id=None,
     ):
         try:

--- a/polybot/service.py
+++ b/polybot/service.py
@@ -50,13 +50,11 @@ class Service(object):
         in_reply_to_id=None,
     ):
         if self.live:
-            if isinstance(status, list):
-                status = self.longest_allowed(status, imagefile)
             if wrap:
                 return self.do_wrapped(status, imagefile, mime_type, lat, lon, in_reply_to_id)
-            else:
-                return self.do_post(status, imagefile, mime_type, lat, lon, in_reply_to_id)
-            self.do_post(status, imagefile, lat, lon)
+            if isinstance(status, list):
+                status = self.longest_allowed(status, imagefile)
+            return self.do_post(status, imagefile, mime_type, lat, lon, in_reply_to_id)
 
     def do_post(
         self,


### PR DESCRIPTION
Just noticed my bots had stopped working at Christmas, looks like when the mime_type branch was merged it conflicted, the conflicts were committed, then removed when supply-list-of-lengths was merged but losing the changes. Also a bit of a tidy from the wrap merge. And a 'return' had disappeared from update_with_media call.